### PR TITLE
Add default tracing of sinatra

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,5 @@ source "https://rubygems.org"
 
 gem "dogstatsd-ruby"
 gem "sinatra"
+gem "ddtrace"
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,10 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    ddtrace (0.10.0)
+      msgpack
     dogstatsd-ruby (3.0.0)
+    msgpack (1.1.0)
     mustermann (1.0.1)
     rack (2.0.3)
     rack-protection (2.0.0)
@@ -17,6 +20,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  ddtrace
   dogstatsd-ruby
   sinatra
 

--- a/app.rb
+++ b/app.rb
@@ -1,5 +1,8 @@
 require "sinatra"
 require 'datadog/statsd'
+require 'ddtrace'
+require 'ddtrace/contrib/sinatra/tracer'
+
 statsd = Datadog::Statsd.new('localhost', 8125)
 
 get "/" do
@@ -7,3 +10,4 @@ get "/" do
 
   render :html, :index
 end
+


### PR DESCRIPTION
Just the default integration.

It might not be the nicest traces, but at least you'll get in the logs if it fails to flush.