### PR TITLE
Upgrade `rack` dep to 2.0.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ GEM
     dogstatsd-ruby (3.3.0)
     msgpack (1.2.4)
     mustermann (1.0.2)
-    rack (2.0.4)
+    rack (2.0.6)
     rack-protection (2.0.1)
       rack
     sinatra (2.0.1)


### PR DESCRIPTION
Minimal upgrade to `rack` to address CVE-2018-16470 and CVE-2018-16471